### PR TITLE
TestExampleJob: fix package name and add comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ return this
 Now using the Jenkins Pipeline Unit you can unit test if it does the job :
 
 ```groovy
-import com.lesfurets.jenkins.helpers.BasePipelineTest
+// Example Groovy test
+import com.lesfurets.jenkins.unit.BasePipelineTest
 
 class TestExampleJob extends BasePipelineTest {
         


### PR DESCRIPTION
~I also had to change `script.execute()` to `script.run()` for my Java-based test, but for all I know Groovy does something clever with an extension method, so I haven't changed it in the example.~